### PR TITLE
Bugfix/wdb5 6

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.cs]
+indent_style = space
+indent_size = 4

--- a/DBClientFiles.NET.Data/WDB2/AchievementEntry.cs
+++ b/DBClientFiles.NET.Data/WDB2/AchievementEntry.cs
@@ -21,4 +21,25 @@ namespace DBClientFiles.NET.Data.WDB2
         public uint MinimumCriteria { get; set; }
         public uint SharesCriteria { get; set; }
     }
+
+	[DBFileName(Name = "Achievement.WDB2", Extension = FileExtension.DB2)]
+	public sealed class AchievementEntry_725_24393
+	{
+		public string Title { get; set; }
+		public string Description { get; set; }
+		public uint Flags { get; set; }
+		public string Rewards { get; set; }
+		public ushort MapID { get; set; }
+		public ushort Supercedes { get; set; }
+		public ushort Category { get; set; }
+		public ushort UIOrder { get; set; }
+		public ushort SharesCriteria { get; set; }
+		public ushort CriteriaTree { get; set; }
+		public byte Faction { get; set; }
+		public byte Points { get; set; }
+		public byte MinimumCriteria { get; set; }
+		[Index]
+		public ushort ID { get; set; }
+		public uint IconID { get; set; } // this is a 24bit integer
+	}
 }

--- a/DBClientFiles.NET.Data/WDB2/AchievementEntry.cs
+++ b/DBClientFiles.NET.Data/WDB2/AchievementEntry.cs
@@ -22,24 +22,24 @@ namespace DBClientFiles.NET.Data.WDB2
         public uint SharesCriteria { get; set; }
     }
 
-	[DBFileName(Name = "Achievement.WDB2", Extension = FileExtension.DB2)]
-	public sealed class AchievementEntry_725_24393
-	{
-		public string Title { get; set; }
-		public string Description { get; set; }
-		public uint Flags { get; set; }
-		public string Rewards { get; set; }
-		public ushort MapID { get; set; }
-		public ushort Supercedes { get; set; }
-		public ushort Category { get; set; }
-		public ushort UIOrder { get; set; }
-		public ushort SharesCriteria { get; set; }
-		public ushort CriteriaTree { get; set; }
-		public byte Faction { get; set; }
-		public byte Points { get; set; }
-		public byte MinimumCriteria { get; set; }
-		[Index]
-		public ushort ID { get; set; }
-		public uint IconID { get; set; } // this is a 24bit integer
-	}
+    [DBFileName(Name = "Achievement.WDB2", Extension = FileExtension.DB2)]
+    public sealed class AchievementEntry_725_24393
+    {
+        public string Title { get; set; }
+        public string Description { get; set; }
+        public uint Flags { get; set; }
+        public string Rewards { get; set; }
+        public ushort MapID { get; set; }
+        public ushort Supercedes { get; set; }
+        public ushort Category { get; set; }
+        public ushort UIOrder { get; set; }
+        public ushort SharesCriteria { get; set; }
+        public ushort CriteriaTree { get; set; }
+        public byte Faction { get; set; }
+        public byte Points { get; set; }
+        public byte MinimumCriteria { get; set; }
+        [Index]
+        public ushort ID { get; set; }
+        public uint IconID { get; set; } // this is a 24bit integer
+    }
 }

--- a/DBClientFiles.NET.Data/WDB2/AchievementEntry.cs
+++ b/DBClientFiles.NET.Data/WDB2/AchievementEntry.cs
@@ -23,6 +23,28 @@ namespace DBClientFiles.NET.Data.WDB2
     }
 
     [DBFileName(Name = "Achievement.WDB2", Extension = FileExtension.DB2)]
+    public sealed class AchievementEntry_715_23420
+    {
+        public string Title { get; set; }
+        public string Description { get; set; }
+        public uint Flags { get; set; }
+        public string Rewards { get; set; }
+        public ushort MapID { get; set; }
+        public ushort Supercedes { get; set; }
+        public ushort Category { get; set; }
+        public ushort UIOrder { get; set; }
+        public ushort Field18 { get; set; }
+        public ushort SharesCriteria { get; set; }
+        public ushort CriteriaTree { get; set; }
+        public byte Faction { get; set; }
+        public byte Points { get; set; }
+        public byte MinimumCriteria { get; set; }
+        [Index]
+        public ushort ID { get; set; }
+
+    }
+
+    [DBFileName(Name = "Achievement.WDB2", Extension = FileExtension.DB2)]
     public sealed class AchievementEntry_725_24393
     {
         public string Title { get; set; }

--- a/DBClientFiles.NET.Data/WDB2/ItemSparseEntry.cs
+++ b/DBClientFiles.NET.Data/WDB2/ItemSparseEntry.cs
@@ -1,0 +1,87 @@
+﻿using DBClientFiles.NET.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DBClientFiles.NET.Data.WDB2
+{
+    [DBFileName(Name = "ItemSparse.WDB2", Extension = FileExtension.DB2)]
+    public sealed class ItemSparseEntry_725_24393
+    {
+        [Index]
+        public int ID { get; set; }
+        [Cardinality(SizeConst = 3)]
+        public uint Flags { get; set; }
+        public float Field02 { get; set; }
+        public float Field03 { get; set; }
+        public uint BuyCount { get; set; }
+        public uint BuyPrice { get; set; }
+        public uint SellPrice { get; set; }
+        public int AllowableRace { get; set; }
+        public uint RequiredSpell { get; set; }
+        public uint MaxCount { get; set; }
+        public uint Stackable { get; set; }
+        [Cardinality(SizeConst = 10)]
+        public int ItemStatAllocation { get; set; }
+        [Cardinality(SizeConst = 10)]
+        public float ItemStatSocketCostMultiplier { get; set; }
+        public float RangedModRange { get; set; }
+        public string Name { get; set; }
+        public string Name2 { get; set; }
+        public string Name3 { get; set; }
+        public string Name4 { get; set; }
+        public string Description { get; set; }
+        public uint BagFamily { get; set; }
+        public float ArmorDamageModifier { get; set; }
+        public uint Duration { get; set; }
+        public float StatScalingFactor { get; set; }
+        public ushort AllowableClass { get; set; }
+        public ushort ItemLevel { get; set; }
+        public ushort RequiredSkill { get; set; }
+        public ushort RequiredSkillRank { get; set; }
+        public ushort RequiredReputationFaction { get; set; }
+        [Cardinality(SizeConst = 10)]
+        public ushort ItemStatValue { get; set; }
+        public ushort ScalingStatDistribution { get; set; }
+        public ushort Delay { get; set; }
+        public ushort PageText { get; set; }
+        public ushort StartQuest { get; set; }
+        public ushort LockID { get; set; }
+        public ushort RandomProperty { get; set; }
+        public ushort RandomSuffix { get; set; }
+        public ushort ItemSet { get; set; }
+        public ushort Area { get; set; }
+        public ushort Map { get; set; }
+        public ushort TotemCategory { get; set; }
+        public ushort SocketBonus { get; set; }
+        public ushort GemProperties { get; set; }
+        public ushort ItemLimitCategory { get; set; }
+        public ushort HolidayID { get; set; }
+        public ushort RequiredTransmogHolidayID { get; set; }
+        public ushort ItemNameDescriptionID { get; set; }
+        public byte Quality { get; set; }
+        public byte InventoryType { get; set; }
+        public byte RequiredLevel { get; set; }
+        public byte RequiredHonorRank { get; set; }
+        public byte RequiredCityRank { get; set; }
+        public byte RequiredReputationRank { get; set; }
+        public byte ContainerSlots { get; set; }
+        [Cardinality(SizeConst = 10)]
+        public byte ItemStatType { get; set; }
+        public byte DamageType { get; set; }
+        public byte Bonding { get; set; }
+        public byte LanguageID { get; set; }
+        public byte PageMaterial { get; set; }
+        public byte Material { get; set; }
+        public byte Sheath { get; set; }
+        [Cardinality(SizeConst = 3)]
+        public byte SocketColor { get; set; }
+        public byte CurrencySubstitutionID { get; set; }
+        public byte CurrencySubstitutionCount { get; set; }
+        public byte ArtifactID { get; set; }
+        public byte RequiredExpansion { get; set; }
+
+    }
+}

--- a/DBClientFiles.NET.Data/WDB2/ItemSparseEntry.cs
+++ b/DBClientFiles.NET.Data/WDB2/ItemSparseEntry.cs
@@ -8,6 +8,83 @@ using System.Threading.Tasks;
 namespace DBClientFiles.NET.Data.WDB2
 {
     [DBFileName(Name = "ItemSparse.WDB2", Extension = FileExtension.DB2)]
+    public sealed class ItemSparseEntry_715_23420
+    {
+        [Index]
+        public int ID { get; set; }
+        [Cardinality(SizeConst = 3)]
+        public int[] Field00 { get; set; }
+        public float Field0C { get; set; }
+        public float Field10 { get; set; }
+        public int Field14 { get; set; }
+        public int Field18 { get; set; }
+        public int Field1C { get; set; }
+        public int Field20 { get; set; }
+        public int Field24 { get; set; }
+        public int Field28 { get; set; }
+        public int Field2C { get; set; }
+        [Cardinality(SizeConst = 10)]
+        public int[] Field30 { get; set; }
+        [Cardinality(SizeConst = 10)]
+        public float[] Field58 { get; set; }
+        public float Field80 { get; set; }
+        public string Field84 { get; set; }
+        public string Field88 { get; set; }
+        public string Field8C { get; set; }
+        public string Field90 { get; set; }
+        public string Field94 { get; set; }
+        public int Field98 { get; set; }
+        public float Field9C { get; set; }
+        public int FieldA0 { get; set; }
+        public float FieldA4 { get; set; }
+        public ushort FieldA8 { get; set; }
+        public ushort FieldAA { get; set; }
+        public ushort FieldAC { get; set; }
+        public ushort FieldAE { get; set; }
+        [Cardinality(SizeConst = 10)]
+        public ushort[] FieldB0 { get; set; }
+        public ushort FieldC4 { get; set; }
+        public ushort FieldC6 { get; set; }
+        public ushort FieldC8 { get; set; }
+        public ushort FieldCA { get; set; }
+        public ushort FieldCC { get; set; }
+        public ushort FieldCE { get; set; }
+        public ushort FieldD0 { get; set; }
+        public ushort FieldD2 { get; set; }
+        public ushort FieldD4 { get; set; }
+        public ushort FieldD6 { get; set; }
+        public ushort FieldD8 { get; set; }
+        public ushort FieldDA { get; set; }
+        public ushort FieldDC { get; set; }
+        public ushort FieldDE { get; set; }
+        public ushort FieldE0 { get; set; }
+        public byte FieldE2 { get; set; }
+        public byte FieldE3 { get; set; }
+        public byte FieldE4 { get; set; }
+        public byte FieldE5 { get; set; }
+        public byte FieldE6 { get; set; }
+        public byte FieldE7 { get; set; }
+        public byte FieldE8 { get; set; }
+        public byte FieldE9 { get; set; }
+        [Cardinality(SizeConst = 10)]
+        public byte[] FieldEA { get; set; }
+        public byte FieldF4 { get; set; }
+        public byte FieldF5 { get; set; }
+        public byte FieldF6 { get; set; }
+        public byte FieldF7 { get; set; }
+        public byte FieldF8 { get; set; }
+        public byte FieldF9 { get; set; }
+        public byte FieldFA { get; set; }
+        [Cardinality(SizeConst = 3)]
+        public byte[] FieldFB { get; set; }
+        public byte FieldFE { get; set; }
+        public byte FieldFF { get; set; }
+        public byte Field100 { get; set; }
+        public byte Field101 { get; set; }
+    }
+
+
+    [DBFileName(Name = "ItemSparse.WDB2", Extension = FileExtension.DB2)]
     public sealed class ItemSparseEntry_725_24393
     {
         [Index]

--- a/DBClientFiles.NET.Data/WDB2/ItemSparseEntry.cs
+++ b/DBClientFiles.NET.Data/WDB2/ItemSparseEntry.cs
@@ -13,7 +13,7 @@ namespace DBClientFiles.NET.Data.WDB2
         [Index]
         public int ID { get; set; }
         [Cardinality(SizeConst = 3)]
-        public uint Flags { get; set; }
+        public uint[] Flags { get; set; }
         public float Field02 { get; set; }
         public float Field03 { get; set; }
         public uint BuyCount { get; set; }
@@ -24,9 +24,9 @@ namespace DBClientFiles.NET.Data.WDB2
         public uint MaxCount { get; set; }
         public uint Stackable { get; set; }
         [Cardinality(SizeConst = 10)]
-        public int ItemStatAllocation { get; set; }
+        public int[] ItemStatAllocation { get; set; }
         [Cardinality(SizeConst = 10)]
-        public float ItemStatSocketCostMultiplier { get; set; }
+        public float[] ItemStatSocketCostMultiplier { get; set; }
         public float RangedModRange { get; set; }
         public string Name { get; set; }
         public string Name2 { get; set; }
@@ -43,7 +43,7 @@ namespace DBClientFiles.NET.Data.WDB2
         public ushort RequiredSkillRank { get; set; }
         public ushort RequiredReputationFaction { get; set; }
         [Cardinality(SizeConst = 10)]
-        public ushort ItemStatValue { get; set; }
+        public ushort[] ItemStatValue { get; set; }
         public ushort ScalingStatDistribution { get; set; }
         public ushort Delay { get; set; }
         public ushort PageText { get; set; }
@@ -69,7 +69,7 @@ namespace DBClientFiles.NET.Data.WDB2
         public byte RequiredReputationRank { get; set; }
         public byte ContainerSlots { get; set; }
         [Cardinality(SizeConst = 10)]
-        public byte ItemStatType { get; set; }
+        public byte[] ItemStatType { get; set; }
         public byte DamageType { get; set; }
         public byte Bonding { get; set; }
         public byte LanguageID { get; set; }
@@ -77,7 +77,7 @@ namespace DBClientFiles.NET.Data.WDB2
         public byte Material { get; set; }
         public byte Sheath { get; set; }
         [Cardinality(SizeConst = 3)]
-        public byte SocketColor { get; set; }
+        public byte[] SocketColor { get; set; }
         public byte CurrencySubstitutionID { get; set; }
         public byte CurrencySubstitutionCount { get; set; }
         public byte ArtifactID { get; set; }

--- a/DBClientFiles.NET.Data/WDB2/WmoMinimapTextureEntry.cs
+++ b/DBClientFiles.NET.Data/WDB2/WmoMinimapTextureEntry.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 namespace DBClientFiles.NET.Data.WDB2
 {
     [DBFileName(Name = "WMOMinimapTexture.WDB2", Extension = FileExtension.DB2)]
-    public sealed class WMOMinimapTextureEntry_725_24393
+    public sealed class WMOMinimapTextureEntry
     {
         [Index]
         public int Id { get; set; }

--- a/DBClientFiles.NET.Data/WDB2/WmoMinimapTextureEntry.cs
+++ b/DBClientFiles.NET.Data/WDB2/WmoMinimapTextureEntry.cs
@@ -1,0 +1,21 @@
+﻿using DBClientFiles.NET.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DBClientFiles.NET.Data.WDB2
+{
+    [DBFileName(Name = "WMOMinimapTexture.WDB2", Extension = FileExtension.DB2)]
+    public sealed class WMOMinimapTextureEntry_725_24393
+    {
+        [Index]
+        public int Id { get; set; }
+        public int FileDataID { get; set; }
+        public ushort WMOID { get; set; }
+        public ushort GroupNum { get; set; }
+        public byte BlockX { get; set; }
+        public byte BlockY { get; set; }
+    }
+}

--- a/DBClientFiles.NET.sln
+++ b/DBClientFiles.NET.sln
@@ -15,6 +15,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DBClientFiles.NET.Definitio
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DBClientFiles.NET.Mapper", "DBClientFiles.NET.Mapper\DBClientFiles.NET.Mapper.csproj", "{FC857F2A-7C08-4875-ADEE-73DFAB38F041}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{7DA58B38-9039-41A6-9813-1556DA2B3DAB}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/DBClientFiles.NET/IO/RecordReader.cs
+++ b/DBClientFiles.NET/IO/RecordReader.cs
@@ -11,40 +11,40 @@ namespace DBClientFiles.NET.IO
     /// </summary>
     public static class _RecordReader
     {
-        private static Type[] arrayArgs            = { typeof(int) };
-        private static Type[] arrayPackedArgs      = { typeof(int), typeof(int), typeof(int) };
-        private static Type[] packedArgs           = { typeof(int), typeof(int) };
+        private static Type[] arrayArgs = { typeof(int) };
+        private static Type[] arrayPackedArgs = { typeof(int), typeof(int), typeof(int) };
+        private static Type[] packedArgs = { typeof(int), typeof(int) };
 
-        public static readonly MethodInfo ReadPackedUInt64  = typeof(RecordReader).GetMethod("ReadUInt64", packedArgs);
-        public static readonly MethodInfo ReadPackedUInt32  = typeof(RecordReader).GetMethod("ReadUInt32", packedArgs);
-        public static readonly MethodInfo ReadPackedUInt16  = typeof(RecordReader).GetMethod("ReadUInt16", packedArgs);
-        public static readonly MethodInfo ReadPackedSByte   = typeof(RecordReader).GetMethod("ReadSByte",  packedArgs);
+        public static readonly MethodInfo ReadPackedUInt64 = typeof(RecordReader).GetMethod("ReadUInt64", packedArgs);
+        public static readonly MethodInfo ReadPackedUInt32 = typeof(RecordReader).GetMethod("ReadUInt32", packedArgs);
+        public static readonly MethodInfo ReadPackedUInt16 = typeof(RecordReader).GetMethod("ReadUInt16", packedArgs);
+        public static readonly MethodInfo ReadPackedSByte = typeof(RecordReader).GetMethod("ReadSByte", packedArgs);
 
-        public static readonly MethodInfo ReadPackedInt64   = typeof(RecordReader).GetMethod("ReadInt64", packedArgs);
-        public static readonly MethodInfo ReadPackedInt32   = typeof(RecordReader).GetMethod("ReadInt32", packedArgs);
-        public static readonly MethodInfo ReadPackedInt16   = typeof(RecordReader).GetMethod("ReadInt16", packedArgs);
-        public static readonly MethodInfo ReadPackedByte    = typeof(RecordReader).GetMethod("ReadByte",  packedArgs);
+        public static readonly MethodInfo ReadPackedInt64 = typeof(RecordReader).GetMethod("ReadInt64", packedArgs);
+        public static readonly MethodInfo ReadPackedInt32 = typeof(RecordReader).GetMethod("ReadInt32", packedArgs);
+        public static readonly MethodInfo ReadPackedInt16 = typeof(RecordReader).GetMethod("ReadInt16", packedArgs);
+        public static readonly MethodInfo ReadPackedByte = typeof(RecordReader).GetMethod("ReadByte", packedArgs);
 
-        public static readonly MethodInfo ReadPackedSingle  = typeof(RecordReader).GetMethod("ReadSingle", new[] { typeof(int) });
+        public static readonly MethodInfo ReadPackedSingle = typeof(RecordReader).GetMethod("ReadSingle", new[] { typeof(int) });
 
-        public static readonly MethodInfo ReadPackedString  = typeof(RecordReader).GetMethod("ReadString", packedArgs);
+        public static readonly MethodInfo ReadPackedString = typeof(RecordReader).GetMethod("ReadString", packedArgs);
         public static readonly MethodInfo ReadPackedStrings = typeof(RecordReader).GetMethod("ReadStrings", arrayPackedArgs);
-        public static readonly MethodInfo ReadPackedArray   = typeof(RecordReader).GetMethod("ReadArray", arrayPackedArgs);
+        public static readonly MethodInfo ReadPackedArray = typeof(RecordReader).GetMethod("ReadArray", arrayPackedArgs);
 
-        public static readonly MethodInfo ReadUInt64        = typeof(RecordReader).GetMethod("ReadUInt64", Type.EmptyTypes);
-        public static readonly MethodInfo ReadUInt32        = typeof(RecordReader).GetMethod("ReadUInt32", Type.EmptyTypes);
-        public static readonly MethodInfo ReadUInt16        = typeof(RecordReader).GetMethod("ReadUInt16", Type.EmptyTypes);
-        public static readonly MethodInfo ReadSByte         = typeof(RecordReader).GetMethod("ReadSByte", Type.EmptyTypes);
+        public static readonly MethodInfo ReadUInt64 = typeof(RecordReader).GetMethod("ReadUInt64", Type.EmptyTypes);
+        public static readonly MethodInfo ReadUInt32 = typeof(RecordReader).GetMethod("ReadUInt32", Type.EmptyTypes);
+        public static readonly MethodInfo ReadUInt16 = typeof(RecordReader).GetMethod("ReadUInt16", Type.EmptyTypes);
+        public static readonly MethodInfo ReadSByte = typeof(RecordReader).GetMethod("ReadSByte", Type.EmptyTypes);
 
-        public static readonly MethodInfo ReadInt64         = typeof(RecordReader).GetMethod("ReadInt64", Type.EmptyTypes);
-        public static readonly MethodInfo ReadInt32         = typeof(RecordReader).GetMethod("ReadInt32", Type.EmptyTypes);
-        public static readonly MethodInfo ReadInt16         = typeof(RecordReader).GetMethod("ReadInt16", Type.EmptyTypes);
-        public static readonly MethodInfo ReadByte          = typeof(RecordReader).GetMethod("ReadByte", Type.EmptyTypes);
+        public static readonly MethodInfo ReadInt64 = typeof(RecordReader).GetMethod("ReadInt64", Type.EmptyTypes);
+        public static readonly MethodInfo ReadInt32 = typeof(RecordReader).GetMethod("ReadInt32", Type.EmptyTypes);
+        public static readonly MethodInfo ReadInt16 = typeof(RecordReader).GetMethod("ReadInt16", Type.EmptyTypes);
+        public static readonly MethodInfo ReadByte = typeof(RecordReader).GetMethod("ReadByte", Type.EmptyTypes);
 
-        public static readonly MethodInfo ReadSingle        = typeof(RecordReader).GetMethod("ReadSingle", Type.EmptyTypes);
-        public static readonly MethodInfo ReadString        = typeof(RecordReader).GetMethod("ReadString", Type.EmptyTypes);
-        public static readonly MethodInfo ReadStrings       = typeof(RecordReader).GetMethod("ReadStrings", arrayArgs);
-        public static readonly MethodInfo ReadArray         = typeof(RecordReader).GetMethod("ReadArray", arrayArgs);
+        public static readonly MethodInfo ReadSingle = typeof(RecordReader).GetMethod("ReadSingle", Type.EmptyTypes);
+        public static readonly MethodInfo ReadString = typeof(RecordReader).GetMethod("ReadString", Type.EmptyTypes);
+        public static readonly MethodInfo ReadStrings = typeof(RecordReader).GetMethod("ReadStrings", arrayArgs);
+        public static readonly MethodInfo ReadArray = typeof(RecordReader).GetMethod("ReadArray", arrayArgs);
 
         public static readonly Dictionary<TypeCode, MethodInfo> PackedReaders = new Dictionary<TypeCode, MethodInfo>()
         {
@@ -87,11 +87,12 @@ namespace DBClientFiles.NET.IO
         //private GCHandle _dataHandle;
         //private IntPtr _dataPointer;
 
-        protected int _bitCursor {
+        protected int _bitCursor
+        {
             get;
-            set; 
+            set;
         } = 0;
-    
+
         public long ReadInt64() => Read<long>(_bitCursor, 64, true);
         public int ReadInt32() => Read<int>(_bitCursor, 32, true);
         public short ReadInt16() => Read<short>(_bitCursor, 16, true);
@@ -248,7 +249,7 @@ namespace DBClientFiles.NET.IO
         {
             if (advanceCursor)
                 _bitCursor += SizeCache<T>.Size * 8;
-            
+
             //! Reading whichever is most from SizeCache<T>.Size and (bitCount + (bitOffset & 7) + 7) / 8.
             //! Consider this: Given a field that uses 17 bits, it deserializes as an int32. However, 17 bits fit on 3 bytes, so we would only read three bytes.
             //! MemoryMarshal.Read<int> expects a Span<byte> of Length = 4.
@@ -268,7 +269,7 @@ namespace DBClientFiles.NET.IO
             if (_usesStringTable)
                 return _fileReader.FindStringByOffset(ReadInt32());
 
-            return _fileReader.ReadString();
+            return ReadInlineString();
         }
 
         /// <summary>
@@ -287,16 +288,26 @@ namespace DBClientFiles.NET.IO
                 return _fileReader.FindStringByOffset(ReadInt32(bitOffset, bitCount));
 
             if ((bitOffset & 7) == 0)
-                return _fileReader.ReadString();
+                return ReadInlineString();
 
             throw new InvalidOperationException("Packed strings must be in the string block!");
         }
-        
+
+        private string ReadInlineString()
+        {
+            var byteList = new List<byte>();
+            byte currChar;
+            while ((currChar = ReadByte()) != '\0')
+                byteList.Add(currChar);
+
+            return System.Text.Encoding.UTF8.GetString(byteList.ToArray());
+        }
+
         public long ReadBits(int bitOffset, int bitCount)
         {
             var byteOffset = bitOffset / 8;
             var byteCount = (bitCount + (bitOffset & 7) + 7) / 8;
-            
+
             var value = 0L;
             for (var i = 0; i < byteCount; ++i)
                 value |= (long)(_recordData[i + byteOffset] << (8 * i));

--- a/DBClientFiles.NET/IO/RecordReader.cs
+++ b/DBClientFiles.NET/IO/RecordReader.cs
@@ -288,7 +288,10 @@ namespace DBClientFiles.NET.IO
                 return _fileReader.FindStringByOffset(ReadInt32(bitOffset, bitCount));
 
             if ((bitOffset & 7) == 0)
+            {
+                _bitCursor = bitOffset;
                 return ReadInlineString();
+            }
 
             throw new InvalidOperationException("Packed strings must be in the string block!");
         }

--- a/DBClientFiles.NET/IO/RecordReader.cs
+++ b/DBClientFiles.NET/IO/RecordReader.cs
@@ -11,40 +11,40 @@ namespace DBClientFiles.NET.IO
     /// </summary>
     public static class _RecordReader
     {
-        private static Type[] arrayArgs = { typeof(int) };
-        private static Type[] arrayPackedArgs = { typeof(int), typeof(int), typeof(int) };
-        private static Type[] packedArgs = { typeof(int), typeof(int) };
+        private static Type[] arrayArgs =            { typeof(int) };
+        private static Type[] arrayPackedArgs =      { typeof(int), typeof(int), typeof(int) };
+        private static Type[] packedArgs =           { typeof(int), typeof(int) };
 
-        public static readonly MethodInfo ReadPackedUInt64 = typeof(RecordReader).GetMethod("ReadUInt64", packedArgs);
-        public static readonly MethodInfo ReadPackedUInt32 = typeof(RecordReader).GetMethod("ReadUInt32", packedArgs);
-        public static readonly MethodInfo ReadPackedUInt16 = typeof(RecordReader).GetMethod("ReadUInt16", packedArgs);
-        public static readonly MethodInfo ReadPackedSByte = typeof(RecordReader).GetMethod("ReadSByte", packedArgs);
+        public static readonly MethodInfo ReadPackedUInt64  = typeof(RecordReader).GetMethod("ReadUInt64", packedArgs);
+        public static readonly MethodInfo ReadPackedUInt32  = typeof(RecordReader).GetMethod("ReadUInt32", packedArgs);
+        public static readonly MethodInfo ReadPackedUInt16  = typeof(RecordReader).GetMethod("ReadUInt16", packedArgs);
+        public static readonly MethodInfo ReadPackedSByte   = typeof(RecordReader).GetMethod("ReadSByte", packedArgs);
 
-        public static readonly MethodInfo ReadPackedInt64 = typeof(RecordReader).GetMethod("ReadInt64", packedArgs);
-        public static readonly MethodInfo ReadPackedInt32 = typeof(RecordReader).GetMethod("ReadInt32", packedArgs);
-        public static readonly MethodInfo ReadPackedInt16 = typeof(RecordReader).GetMethod("ReadInt16", packedArgs);
-        public static readonly MethodInfo ReadPackedByte = typeof(RecordReader).GetMethod("ReadByte", packedArgs);
+        public static readonly MethodInfo ReadPackedInt64   = typeof(RecordReader).GetMethod("ReadInt64", packedArgs);
+        public static readonly MethodInfo ReadPackedInt32   = typeof(RecordReader).GetMethod("ReadInt32", packedArgs);
+        public static readonly MethodInfo ReadPackedInt16   = typeof(RecordReader).GetMethod("ReadInt16", packedArgs);
+        public static readonly MethodInfo ReadPackedByte    = typeof(RecordReader).GetMethod("ReadByte", packedArgs);
 
-        public static readonly MethodInfo ReadPackedSingle = typeof(RecordReader).GetMethod("ReadSingle", new[] { typeof(int) });
+        public static readonly MethodInfo ReadPackedSingle  = typeof(RecordReader).GetMethod("ReadSingle", new[] { typeof(int) });
 
-        public static readonly MethodInfo ReadPackedString = typeof(RecordReader).GetMethod("ReadString", packedArgs);
+        public static readonly MethodInfo ReadPackedString  = typeof(RecordReader).GetMethod("ReadString", packedArgs);
         public static readonly MethodInfo ReadPackedStrings = typeof(RecordReader).GetMethod("ReadStrings", arrayPackedArgs);
-        public static readonly MethodInfo ReadPackedArray = typeof(RecordReader).GetMethod("ReadArray", arrayPackedArgs);
+        public static readonly MethodInfo ReadPackedArray   = typeof(RecordReader).GetMethod("ReadArray", arrayPackedArgs);
 
-        public static readonly MethodInfo ReadUInt64 = typeof(RecordReader).GetMethod("ReadUInt64", Type.EmptyTypes);
-        public static readonly MethodInfo ReadUInt32 = typeof(RecordReader).GetMethod("ReadUInt32", Type.EmptyTypes);
-        public static readonly MethodInfo ReadUInt16 = typeof(RecordReader).GetMethod("ReadUInt16", Type.EmptyTypes);
-        public static readonly MethodInfo ReadSByte = typeof(RecordReader).GetMethod("ReadSByte", Type.EmptyTypes);
+        public static readonly MethodInfo ReadUInt64        = typeof(RecordReader).GetMethod("ReadUInt64", Type.EmptyTypes);
+        public static readonly MethodInfo ReadUInt32        = typeof(RecordReader).GetMethod("ReadUInt32", Type.EmptyTypes);
+        public static readonly MethodInfo ReadUInt16        = typeof(RecordReader).GetMethod("ReadUInt16", Type.EmptyTypes);
+        public static readonly MethodInfo ReadSByte         = typeof(RecordReader).GetMethod("ReadSByte", Type.EmptyTypes);
 
-        public static readonly MethodInfo ReadInt64 = typeof(RecordReader).GetMethod("ReadInt64", Type.EmptyTypes);
-        public static readonly MethodInfo ReadInt32 = typeof(RecordReader).GetMethod("ReadInt32", Type.EmptyTypes);
-        public static readonly MethodInfo ReadInt16 = typeof(RecordReader).GetMethod("ReadInt16", Type.EmptyTypes);
-        public static readonly MethodInfo ReadByte = typeof(RecordReader).GetMethod("ReadByte", Type.EmptyTypes);
+        public static readonly MethodInfo ReadInt64         = typeof(RecordReader).GetMethod("ReadInt64", Type.EmptyTypes);
+        public static readonly MethodInfo ReadInt32         = typeof(RecordReader).GetMethod("ReadInt32", Type.EmptyTypes);
+        public static readonly MethodInfo ReadInt16         = typeof(RecordReader).GetMethod("ReadInt16", Type.EmptyTypes);
+        public static readonly MethodInfo ReadByte          = typeof(RecordReader).GetMethod("ReadByte", Type.EmptyTypes);
 
-        public static readonly MethodInfo ReadSingle = typeof(RecordReader).GetMethod("ReadSingle", Type.EmptyTypes);
-        public static readonly MethodInfo ReadString = typeof(RecordReader).GetMethod("ReadString", Type.EmptyTypes);
-        public static readonly MethodInfo ReadStrings = typeof(RecordReader).GetMethod("ReadStrings", arrayArgs);
-        public static readonly MethodInfo ReadArray = typeof(RecordReader).GetMethod("ReadArray", arrayArgs);
+        public static readonly MethodInfo ReadSingle        = typeof(RecordReader).GetMethod("ReadSingle", Type.EmptyTypes);
+        public static readonly MethodInfo ReadString        = typeof(RecordReader).GetMethod("ReadString", Type.EmptyTypes);
+        public static readonly MethodInfo ReadStrings       = typeof(RecordReader).GetMethod("ReadStrings", arrayArgs);
+        public static readonly MethodInfo ReadArray         = typeof(RecordReader).GetMethod("ReadArray", arrayArgs);
 
         public static readonly Dictionary<TypeCode, MethodInfo> PackedReaders = new Dictionary<TypeCode, MethodInfo>()
         {

--- a/DBClientFiles.NET/Internals/Binding/ExtendedMemberInfoCollection.cs
+++ b/DBClientFiles.NET/Internals/Binding/ExtendedMemberInfoCollection.cs
@@ -80,10 +80,10 @@ namespace DBClientFiles.NET.Internals.Binding
             FileMembers.AddRange(fileMembers);
         }
 
-        internal void AddFileMemberInfo(BinaryReader reader)
+        internal void AddFileMemberInfo(BinaryReader reader, bool hasOffsetMap = false)
         {
             var instance = new FileMemberInfo();
-            instance.Initialize(reader);
+            instance.Initialize(reader, hasOffsetMap);
             instance.Index = FileMembers.Count;
             FileMembers.Add(instance);
         }
@@ -153,9 +153,9 @@ namespace DBClientFiles.NET.Internals.Binding
                 if (currentFileMember.ByteSize > 0)
                     currentFileMember.Cardinality = currentFileMember.BitSize / (8 * currentFileMember.ByteSize);
 
-                // Calculate cardinality from FileMembers offsets 
+                // Calculate cardinality from FileMember offsets
                 if (currentFileMember.Cardinality <= 1 && i < FileMembers.Count - 1)
-                    currentFileMember.Cardinality = Math.Max(1, (FileMembers[i + 1].Offset - currentFileMember.Offset) / currentFileMember.BitSize);
+                    currentFileMember.Cardinality = ((FileMembers[i + 1].Offset - currentFileMember.Offset) / 8) / currentFileMember.ByteSize;
             }
 
             // Throw an exception if we mapped to a field that wasn't declared as an array

--- a/DBClientFiles.NET/Internals/Binding/ExtendedMemberInfoCollection.cs
+++ b/DBClientFiles.NET/Internals/Binding/ExtendedMemberInfoCollection.cs
@@ -80,10 +80,10 @@ namespace DBClientFiles.NET.Internals.Binding
             FileMembers.AddRange(fileMembers);
         }
 
-        internal void AddFileMemberInfo(BinaryReader reader, bool hasOffsetMap = false)
+        internal void AddFileMemberInfo(BinaryReader reader)
         {
             var instance = new FileMemberInfo();
-            instance.Initialize(reader, hasOffsetMap);
+            instance.Initialize(reader);
             instance.Index = FileMembers.Count;
             FileMembers.Add(instance);
         }

--- a/DBClientFiles.NET/Internals/Binding/ExtendedMemberInfoCollection.cs
+++ b/DBClientFiles.NET/Internals/Binding/ExtendedMemberInfoCollection.cs
@@ -15,7 +15,7 @@ namespace DBClientFiles.NET.Internals.Binding
         public List<ExtendedMemberInfo> Members { get; } = new List<ExtendedMemberInfo>();
 
         public List<FileMemberInfo> FileMembers { get; } = new List<FileMemberInfo>();
-        
+
         internal ExtendedMemberInfoCollection(Type parentType, StorageOptions options)
         {
             if (parentType == null)
@@ -59,7 +59,7 @@ namespace DBClientFiles.NET.Internals.Binding
             {
                 if (IndexColumn == -1)
                     throw new InvalidOperationException("Index column not bound");
-                
+
                 for (var i = 0; i < Members.Count; ++i)
                 {
                     var memberInfo = Members[i];
@@ -69,7 +69,7 @@ namespace DBClientFiles.NET.Internals.Binding
                     if (memberInfo.MappedTo != null && memberInfo.MappedTo.Index == IndexColumn)
                         return memberInfo;
                 }
-                
+
                 throw new InvalidOperationException("Unable to find index");
             }
         }
@@ -152,6 +152,10 @@ namespace DBClientFiles.NET.Internals.Binding
 
                 if (currentFileMember.ByteSize > 0)
                     currentFileMember.Cardinality = currentFileMember.BitSize / (8 * currentFileMember.ByteSize);
+
+                // Calculate cardinality from FileMembers offsets 
+                if (currentFileMember.Cardinality <= 1 && i < FileMembers.Count - 1)
+                    currentFileMember.Cardinality = Math.Max(1, (FileMembers[i + 1].Offset - currentFileMember.Offset) / currentFileMember.BitSize);
             }
 
             // Throw an exception if we mapped to a field that wasn't declared as an array

--- a/DBClientFiles.NET/Internals/Binding/FileMemberInfo.cs
+++ b/DBClientFiles.NET/Internals/Binding/FileMemberInfo.cs
@@ -64,11 +64,13 @@ namespace DBClientFiles.NET.Internals.Binding
             return MemoryMarshal.Read<T>(asSpan);
         }
 
-        internal void Initialize(BinaryReader reader)
+        internal void Initialize(BinaryReader reader, bool hasOffsetMap)
         {
             ByteSize = 4 - reader.ReadInt16() / 8;
-            BitSize = ByteSize * 8;
             Offset = reader.ReadInt16() * 8;
+
+            if (!hasOffsetMap)
+                BitSize = ByteSize * 8;
         }
 
         internal void ReadExtra(BinaryReader reader)

--- a/DBClientFiles.NET/Internals/Binding/FileMemberInfo.cs
+++ b/DBClientFiles.NET/Internals/Binding/FileMemberInfo.cs
@@ -64,13 +64,11 @@ namespace DBClientFiles.NET.Internals.Binding
             return MemoryMarshal.Read<T>(asSpan);
         }
 
-        internal void Initialize(BinaryReader reader, bool hasOffsetMap)
+        internal void Initialize(BinaryReader reader)
         {
             ByteSize = 4 - reader.ReadInt16() / 8;
+            BitSize = ByteSize * 8;
             Offset = reader.ReadInt16() * 8;
-
-            if (!hasOffsetMap)
-                BitSize = ByteSize * 8;
         }
 
         internal void ReadExtra(BinaryReader reader)

--- a/DBClientFiles.NET/Internals/Segments/FileHeader.cs
+++ b/DBClientFiles.NET/Internals/Segments/FileHeader.cs
@@ -20,6 +20,7 @@
         int IndexColumn { get; }
         
         bool HasIndexTable { get; }
-        bool HasOffsetMap { get; }
+		bool HasForeignIds { get; }
+		bool HasOffsetMap { get; }
     }
 }

--- a/DBClientFiles.NET/Internals/Segments/Readers/OffsetmapReader.cs
+++ b/DBClientFiles.NET/Internals/Segments/Readers/OffsetmapReader.cs
@@ -15,6 +15,8 @@ namespace DBClientFiles.NET.Internals.Segments.Readers
             if (!Segment.Exists)
                 return;
 
+            HashSet<long> _knownOffsets = new HashSet<long>();
+
             var i = 0;
             FileReader.BaseStream.Seek(Segment.StartOffset, SeekOrigin.Begin);
             while (FileReader.BaseStream.Position < Segment.EndOffset)
@@ -25,7 +27,12 @@ namespace DBClientFiles.NET.Internals.Segments.Readers
                 if (offset == 0 || size == 0)
                     continue;
 
-                _parsedContent.Add(i++, (offset, size));
+                // offset map can contain duplicates which should be excluded
+                if (!_knownOffsets.Contains(offset))
+                {
+                    _parsedContent.Add(i++, (offset, size));
+                    _knownOffsets.Add(offset);
+                }                    
             }
         }
 

--- a/DBClientFiles.NET/Internals/Segments/Readers/OffsetmapReader.cs
+++ b/DBClientFiles.NET/Internals/Segments/Readers/OffsetmapReader.cs
@@ -22,12 +22,10 @@ namespace DBClientFiles.NET.Internals.Segments.Readers
                 long offset = FileReader.ReadInt32();
                 var size = FileReader.ReadInt16();
 
-                ++i;
-
                 if (offset == 0 || size == 0)
                     continue;
 
-                _parsedContent.Add(i, (offset, size));
+                _parsedContent.Add(i++, (offset, size));
             }
         }
 

--- a/DBClientFiles.NET/Internals/Segments/Readers/OffsetmapReader.cs
+++ b/DBClientFiles.NET/Internals/Segments/Readers/OffsetmapReader.cs
@@ -6,7 +6,7 @@ namespace DBClientFiles.NET.Internals.Segments.Readers
 {
     internal sealed class OffsetMapReader : SegmentReader
     {
-        private readonly Dictionary<int, (long, int)> _parsedContent = new Dictionary<int, (long, int)>();
+        private readonly List<(long, int)> _parsedContent = new List<(long, int)>();
 
         public OffsetMapReader(FileReader reader) : base(reader) { }
 
@@ -15,9 +15,8 @@ namespace DBClientFiles.NET.Internals.Segments.Readers
             if (!Segment.Exists)
                 return;
 
-            HashSet<long> _knownOffsets = new HashSet<long>();
+            var _content = new HashSet<(long, int)>();
 
-            var i = 0;
             FileReader.BaseStream.Seek(Segment.StartOffset, SeekOrigin.Begin);
             while (FileReader.BaseStream.Position < Segment.EndOffset)
             {
@@ -27,13 +26,10 @@ namespace DBClientFiles.NET.Internals.Segments.Readers
                 if (offset == 0 || size == 0)
                     continue;
 
-                // offset map can contain duplicates which should be excluded
-                if (!_knownOffsets.Contains(offset))
-                {
-                    _parsedContent.Add(i++, (offset, size));
-                    _knownOffsets.Add(offset);
-                }                    
+                _content.Add((offset, size));
             }
+
+            _parsedContent.AddRange(_content);
         }
 
         public long GetRecordOffset(int index)

--- a/DBClientFiles.NET/Internals/Serializers/CodeGenerator.cs
+++ b/DBClientFiles.NET/Internals/Serializers/CodeGenerator.cs
@@ -442,7 +442,7 @@ namespace DBClientFiles.NET.Internals.Serializers
                         elementType.IsSigned() ? "signed" : "unsigned");
             }
 
-            if (memberInfo.MappedTo.BitSize != 0)
+            if (memberInfo.MappedTo.BitSize != 0 && !Reader.Header.HasOffsetMap)
             {
                 if (memberInfo.Type.IsArray)
                 {

--- a/DBClientFiles.NET/Internals/Versions/Headers/WDB2.cs
+++ b/DBClientFiles.NET/Internals/Versions/Headers/WDB2.cs
@@ -25,7 +25,7 @@ namespace DBClientFiles.NET.Internals.Versions.Headers
                 reader.BaseStream.Position += (4 + 2) * (MaxIndex - MinIndex + 1);
 
             HasIndexTable = false;
-			HasForeignIds = false;
+            HasForeignIds = false;
             HasOffsetMap = false;
 
             IndexColumn = 0;
@@ -46,8 +46,8 @@ namespace DBClientFiles.NET.Internals.Versions.Headers
         public int CopyTableLength { get; }
 
         public bool HasIndexTable { get; }
-		public bool HasForeignIds { get; }
-		public bool HasOffsetMap { get; }
+        public bool HasForeignIds { get; }
+        public bool HasOffsetMap { get; }
 
         public int IndexColumn { get; }
     }

--- a/DBClientFiles.NET/Internals/Versions/Headers/WDB2.cs
+++ b/DBClientFiles.NET/Internals/Versions/Headers/WDB2.cs
@@ -25,6 +25,7 @@ namespace DBClientFiles.NET.Internals.Versions.Headers
                 reader.BaseStream.Position += (4 + 2) * (MaxIndex - MinIndex + 1);
 
             HasIndexTable = false;
+			HasForeignIds = false;
             HasOffsetMap = false;
 
             IndexColumn = 0;
@@ -45,7 +46,8 @@ namespace DBClientFiles.NET.Internals.Versions.Headers
         public int CopyTableLength { get; }
 
         public bool HasIndexTable { get; }
-        public bool HasOffsetMap { get; }
+		public bool HasForeignIds { get; }
+		public bool HasOffsetMap { get; }
 
         public int IndexColumn { get; }
     }

--- a/DBClientFiles.NET/Internals/Versions/Headers/WDB5.cs
+++ b/DBClientFiles.NET/Internals/Versions/Headers/WDB5.cs
@@ -23,7 +23,8 @@ namespace DBClientFiles.NET.Internals.Versions.Headers
             IndexColumn = reader.ReadInt16();
 
             HasIndexTable = (flags & 0x04) != 0;
-            HasOffsetMap = (flags & 0x01) != 0;
+			HasForeignIds = (flags & 0x02) != 0;
+			HasOffsetMap = (flags & 0x01) != 0;
         }
 
         #region IStorage
@@ -43,7 +44,8 @@ namespace DBClientFiles.NET.Internals.Versions.Headers
         public int MaxIndex { get; }
 
         public bool HasIndexTable { get; }
-        public bool HasOffsetMap { get; }
+		public bool HasForeignIds { get; }
+		public bool HasOffsetMap { get; }
 
         public int IndexColumn { get; }
     }

--- a/DBClientFiles.NET/Internals/Versions/Headers/WDB5.cs
+++ b/DBClientFiles.NET/Internals/Versions/Headers/WDB5.cs
@@ -23,8 +23,8 @@ namespace DBClientFiles.NET.Internals.Versions.Headers
             IndexColumn = reader.ReadInt16();
 
             HasIndexTable = (flags & 0x04) != 0;
-			HasForeignIds = (flags & 0x02) != 0;
-			HasOffsetMap = (flags & 0x01) != 0;
+            HasForeignIds = (flags & 0x02) != 0;
+            HasOffsetMap = (flags & 0x01) != 0;
         }
 
         #region IStorage
@@ -44,8 +44,8 @@ namespace DBClientFiles.NET.Internals.Versions.Headers
         public int MaxIndex { get; }
 
         public bool HasIndexTable { get; }
-		public bool HasForeignIds { get; }
-		public bool HasOffsetMap { get; }
+        public bool HasForeignIds { get; }
+        public bool HasOffsetMap { get; }
 
         public int IndexColumn { get; }
     }

--- a/DBClientFiles.NET/Internals/Versions/Headers/WDB6.cs
+++ b/DBClientFiles.NET/Internals/Versions/Headers/WDB6.cs
@@ -23,7 +23,8 @@ namespace DBClientFiles.NET.Internals.Versions.Headers
             IndexColumn = reader.ReadInt16();
 
             HasIndexTable = (flags & 0x04) != 0;
-            HasOffsetMap = (flags & 0x01) != 0;
+			HasForeignIds = (flags & 0x02) != 0;
+			HasOffsetMap = (flags & 0x01) != 0;
         }
 
         #region IStorage
@@ -43,7 +44,8 @@ namespace DBClientFiles.NET.Internals.Versions.Headers
         public int MaxIndex { get; }
 
         public bool HasIndexTable { get; }
-        public bool HasOffsetMap { get; }
+		public bool HasForeignIds { get; }
+		public bool HasOffsetMap { get; }
 
         public int IndexColumn { get; }
     }

--- a/DBClientFiles.NET/Internals/Versions/Headers/WDB6.cs
+++ b/DBClientFiles.NET/Internals/Versions/Headers/WDB6.cs
@@ -23,8 +23,8 @@ namespace DBClientFiles.NET.Internals.Versions.Headers
             IndexColumn = reader.ReadInt16();
 
             HasIndexTable = (flags & 0x04) != 0;
-			HasForeignIds = (flags & 0x02) != 0;
-			HasOffsetMap = (flags & 0x01) != 0;
+            HasForeignIds = (flags & 0x02) != 0;
+            HasOffsetMap = (flags & 0x01) != 0;
         }
 
         #region IStorage
@@ -44,8 +44,8 @@ namespace DBClientFiles.NET.Internals.Versions.Headers
         public int MaxIndex { get; }
 
         public bool HasIndexTable { get; }
-		public bool HasForeignIds { get; }
-		public bool HasOffsetMap { get; }
+        public bool HasForeignIds { get; }
+        public bool HasOffsetMap { get; }
 
         public int IndexColumn { get; }
     }

--- a/DBClientFiles.NET/Internals/Versions/Headers/WDBC.cs
+++ b/DBClientFiles.NET/Internals/Versions/Headers/WDBC.cs
@@ -16,7 +16,7 @@ namespace DBClientFiles.NET.Internals.Versions.Headers
             StringTableLength = reader.ReadInt32();
 
             HasIndexTable = false;
-			HasForeignIds = false;
+            HasForeignIds = false;
             HasOffsetMap = false;
 
             CopyTableLength = 0;
@@ -42,8 +42,8 @@ namespace DBClientFiles.NET.Internals.Versions.Headers
         public int CopyTableLength { get; }
 
         public bool HasIndexTable { get; }
-		public bool HasForeignIds { get; }
-		public bool HasOffsetMap { get; }
+        public bool HasForeignIds { get; }
+        public bool HasOffsetMap { get; }
 
         public int IndexColumn { get; }
     }

--- a/DBClientFiles.NET/Internals/Versions/Headers/WDBC.cs
+++ b/DBClientFiles.NET/Internals/Versions/Headers/WDBC.cs
@@ -16,6 +16,7 @@ namespace DBClientFiles.NET.Internals.Versions.Headers
             StringTableLength = reader.ReadInt32();
 
             HasIndexTable = false;
+			HasForeignIds = false;
             HasOffsetMap = false;
 
             CopyTableLength = 0;
@@ -41,7 +42,8 @@ namespace DBClientFiles.NET.Internals.Versions.Headers
         public int CopyTableLength { get; }
 
         public bool HasIndexTable { get; }
-        public bool HasOffsetMap { get; }
+		public bool HasForeignIds { get; }
+		public bool HasOffsetMap { get; }
 
         public int IndexColumn { get; }
     }

--- a/DBClientFiles.NET/Internals/Versions/Headers/WDC1.cs
+++ b/DBClientFiles.NET/Internals/Versions/Headers/WDC1.cs
@@ -23,7 +23,7 @@ namespace DBClientFiles.NET.Internals.Versions.Headers
             IndexColumn = reader.ReadInt16();
 
             HasIndexTable = (flags & 0x04) != 0;
-			HasForeignIds = (flags & 0x02) != 0;
+            HasForeignIds = (flags & 0x02) != 0;
             HasOffsetMap = (flags & 0x01) != 0;
         }
 
@@ -44,8 +44,8 @@ namespace DBClientFiles.NET.Internals.Versions.Headers
         public int MaxIndex { get; }
 
         public bool HasIndexTable { get; }
-		public bool HasForeignIds { get; }
-		public bool HasOffsetMap { get; }
+        public bool HasForeignIds { get; }
+        public bool HasOffsetMap { get; }
 
         public int IndexColumn { get; }
     }

--- a/DBClientFiles.NET/Internals/Versions/Headers/WDC1.cs
+++ b/DBClientFiles.NET/Internals/Versions/Headers/WDC1.cs
@@ -23,6 +23,7 @@ namespace DBClientFiles.NET.Internals.Versions.Headers
             IndexColumn = reader.ReadInt16();
 
             HasIndexTable = (flags & 0x04) != 0;
+			HasForeignIds = (flags & 0x02) != 0;
             HasOffsetMap = (flags & 0x01) != 0;
         }
 
@@ -43,7 +44,8 @@ namespace DBClientFiles.NET.Internals.Versions.Headers
         public int MaxIndex { get; }
 
         public bool HasIndexTable { get; }
-        public bool HasOffsetMap { get; }
+		public bool HasForeignIds { get; }
+		public bool HasOffsetMap { get; }
 
         public int IndexColumn { get; }
     }

--- a/DBClientFiles.NET/Internals/Versions/Headers/WDC2.cs
+++ b/DBClientFiles.NET/Internals/Versions/Headers/WDC2.cs
@@ -21,7 +21,8 @@ namespace DBClientFiles.NET.Internals.Versions.Headers
             var flags = reader.ReadInt16();
             IndexColumn = reader.ReadInt16();
 
-            HasIndexTable = (flags & 0x04) == 0;
+            HasIndexTable = (flags & 0x04) != 0;
+			HasForeignIds = (flags & 0x02) != 0;
             HasOffsetMap = (flags & 0x01) != 0;
 
             CopyTableLength = 0;
@@ -44,7 +45,8 @@ namespace DBClientFiles.NET.Internals.Versions.Headers
         public int MaxIndex { get; }
 
         public bool HasIndexTable { get; }
-        public bool HasOffsetMap { get; }
+		public bool HasForeignIds { get; }
+		public bool HasOffsetMap { get; }
 
         public int IndexColumn { get; }
     }

--- a/DBClientFiles.NET/Internals/Versions/Headers/WDC2.cs
+++ b/DBClientFiles.NET/Internals/Versions/Headers/WDC2.cs
@@ -22,7 +22,7 @@ namespace DBClientFiles.NET.Internals.Versions.Headers
             IndexColumn = reader.ReadInt16();
 
             HasIndexTable = (flags & 0x04) != 0;
-			HasForeignIds = (flags & 0x02) != 0;
+            HasForeignIds = (flags & 0x02) != 0;
             HasOffsetMap = (flags & 0x01) != 0;
 
             CopyTableLength = 0;
@@ -45,8 +45,8 @@ namespace DBClientFiles.NET.Internals.Versions.Headers
         public int MaxIndex { get; }
 
         public bool HasIndexTable { get; }
-		public bool HasForeignIds { get; }
-		public bool HasOffsetMap { get; }
+        public bool HasForeignIds { get; }
+        public bool HasOffsetMap { get; }
 
         public int IndexColumn { get; }
     }

--- a/DBClientFiles.NET/Internals/Versions/WDB5.cs
+++ b/DBClientFiles.NET/Internals/Versions/WDB5.cs
@@ -68,8 +68,18 @@ namespace DBClientFiles.NET.Internals.Versions
             return true;
         }
 
+        public override void ReadSegments()
+        {
+            base.ReadSegments();
+
+            OffsetMap.Read();
+            _copyTable.Read();
+        }
+
         protected override IEnumerable<TValue> ReadRecords(int recordIndex, long recordOffset, int recordSize)
         {
+            this.BaseStream.Seek(recordOffset, SeekOrigin.Begin);
+
             TValue oldStructure;
             using (var recordReader = new RecordReader(this, StringTable.Exists, recordSize))
             {

--- a/DBClientFiles.NET/Internals/Versions/WDB5.cs
+++ b/DBClientFiles.NET/Internals/Versions/WDB5.cs
@@ -40,7 +40,7 @@ namespace DBClientFiles.NET.Internals.Versions
             Debug.Assert(BaseStream.Position == 48);
 
             for (var i = 0; i < Header.FieldCount; ++i)
-                MemberStore.AddFileMemberInfo(this, Header.HasOffsetMap);
+                MemberStore.AddFileMemberInfo(this);
 
             #region Initialize segments
             Records.StartOffset = BaseStream.Position;

--- a/DBClientFiles.NET/Internals/Versions/WDB5.cs
+++ b/DBClientFiles.NET/Internals/Versions/WDB5.cs
@@ -78,7 +78,7 @@ namespace DBClientFiles.NET.Internals.Versions
 
         protected override IEnumerable<TValue> ReadRecords(int recordIndex, long recordOffset, int recordSize)
         {
-            this.BaseStream.Seek(recordOffset, SeekOrigin.Begin);
+            BaseStream.Seek(recordOffset, SeekOrigin.Begin);
 
             TValue oldStructure;
             using (var recordReader = new RecordReader(this, StringTable.Exists, recordSize))

--- a/DBClientFiles.NET/Internals/Versions/WDB5.cs
+++ b/DBClientFiles.NET/Internals/Versions/WDB5.cs
@@ -40,7 +40,7 @@ namespace DBClientFiles.NET.Internals.Versions
             Debug.Assert(BaseStream.Position == 48);
 
             for (var i = 0; i < Header.FieldCount; ++i)
-                MemberStore.AddFileMemberInfo(this);
+                MemberStore.AddFileMemberInfo(this, Header.HasOffsetMap);
 
             #region Initialize segments
             Records.StartOffset = BaseStream.Position;

--- a/DBClientFiles.NET/Internals/Versions/WDB6.cs
+++ b/DBClientFiles.NET/Internals/Versions/WDB6.cs
@@ -4,6 +4,7 @@ using DBClientFiles.NET.Utils;
 using System.IO;
 using DBClientFiles.NET.Collections;
 using DBClientFiles.NET.Internals.Segments;
+using DBClientFiles.NET.Internals.Serializers;
 
 namespace DBClientFiles.NET.Internals.Versions
 {
@@ -43,33 +44,36 @@ namespace DBClientFiles.NET.Internals.Versions
 
             _commonTableStartColumn = Header.FieldCount;
 
-            #region Initialize segments
-            Records.StartOffset = BaseStream.Position;
+			for (var i = 0; i < Header.FieldCount; ++i)
+				MemberStore.AddFileMemberInfo(this);
+
+			#region Initialize segments
+			Records.StartOffset = BaseStream.Position;
             Records.Length = Header.RecordSize * Header.RecordCount;
 
-            StringTable.Exists = !Header.HasOffsetMap;
             StringTable.StartOffset = Records.EndOffset;
             StringTable.Length = Header.StringTableLength;
+			StringTable.Exists = !Header.HasOffsetMap;
 
-            OffsetMap.Exists = Header.HasOffsetMap;
             OffsetMap.StartOffset = Header.StringTableLength;
             OffsetMap.Length = (Header.MaxIndex - Header.MinIndex + 1) * (4 + 2);
+			OffsetMap.Exists = Header.HasOffsetMap;
 
-            IndexTable.Exists = Header.HasIndexTable;
-            IndexTable.StartOffset = OffsetMap.Exists ? OffsetMap.EndOffset : StringTable.EndOffset;
+			long _foreignIdsLength = Header.HasForeignIds ? (Header.MaxIndex - Header.MinIndex + 1) * 4 : 0;
+
+			IndexTable.StartOffset = (OffsetMap.Exists ? OffsetMap.EndOffset : StringTable.EndOffset) + _foreignIdsLength;
             IndexTable.Length = Header.RecordCount * SizeCache<TKey>.Size;
+			IndexTable.Exists = Header.HasIndexTable;
 
-            _copyTable.StartOffset = IndexTable.EndOffset;
+			_copyTable.StartOffset = IndexTable.EndOffset;
             _copyTable.Length = Header.CopyTableLength;
 
             _commonTable.StartOffset = _copyTable.EndOffset;
             _commonTable.Length = commonDataTableSize;
-            #endregion
+			#endregion
 
-            for (var i = 0; i < Header.FieldCount; ++i)
-                MemberStore.AddFileMemberInfo(this);
-
-            return true;
+			_codeGenerator = new CodeGenerator<TValue, TKey>(this);
+			return true;
         }
 
         public override T ReadCommonMember<T>(int memberIndex,  TValue value)

--- a/DBClientFiles.NET/Internals/Versions/WDB6.cs
+++ b/DBClientFiles.NET/Internals/Versions/WDB6.cs
@@ -22,7 +22,7 @@ namespace DBClientFiles.NET.Internals.Versions
         #region Life and death
         public WDB6(IFileHeader header, Stream strm, StorageOptions options) : base(header, strm, options)
         {
-            _copyTable   = new CopyTableReader<TKey>(this);
+            _copyTable = new CopyTableReader<TKey>(this);
             _commonTable = new LegacyCommonTableReader<TKey>(this);
         }
 
@@ -44,39 +44,39 @@ namespace DBClientFiles.NET.Internals.Versions
 
             _commonTableStartColumn = Header.FieldCount;
 
-			for (var i = 0; i < Header.FieldCount; ++i)
-				MemberStore.AddFileMemberInfo(this);
+            for (var i = 0; i < Header.FieldCount; ++i)
+                MemberStore.AddFileMemberInfo(this);
 
-			#region Initialize segments
-			Records.StartOffset = BaseStream.Position;
+            #region Initialize segments
+            Records.StartOffset = BaseStream.Position;
             Records.Length = Header.RecordSize * Header.RecordCount;
 
             StringTable.StartOffset = Records.EndOffset;
             StringTable.Length = Header.StringTableLength;
-			StringTable.Exists = !Header.HasOffsetMap;
+            StringTable.Exists = !Header.HasOffsetMap;
 
             OffsetMap.StartOffset = Header.StringTableLength;
             OffsetMap.Length = (Header.MaxIndex - Header.MinIndex + 1) * (4 + 2);
-			OffsetMap.Exists = Header.HasOffsetMap;
+            OffsetMap.Exists = Header.HasOffsetMap;
 
-			long _foreignIdsLength = Header.HasForeignIds ? (Header.MaxIndex - Header.MinIndex + 1) * 4 : 0;
+            long _foreignIdsLength = Header.HasForeignIds ? (Header.MaxIndex - Header.MinIndex + 1) * 4 : 0;
 
-			IndexTable.StartOffset = (OffsetMap.Exists ? OffsetMap.EndOffset : StringTable.EndOffset) + _foreignIdsLength;
+            IndexTable.StartOffset = (OffsetMap.Exists ? OffsetMap.EndOffset : StringTable.EndOffset) + _foreignIdsLength;
             IndexTable.Length = Header.RecordCount * SizeCache<TKey>.Size;
-			IndexTable.Exists = Header.HasIndexTable;
+            IndexTable.Exists = Header.HasIndexTable;
 
-			_copyTable.StartOffset = IndexTable.EndOffset;
+            _copyTable.StartOffset = IndexTable.EndOffset;
             _copyTable.Length = Header.CopyTableLength;
 
             _commonTable.StartOffset = _copyTable.EndOffset;
             _commonTable.Length = commonDataTableSize;
-			#endregion
+            #endregion
 
-			_codeGenerator = new CodeGenerator<TValue, TKey>(this);
-			return true;
+            _codeGenerator = new CodeGenerator<TValue, TKey>(this);
+            return true;
         }
 
-        public override T ReadCommonMember<T>(int memberIndex,  TValue value)
+        public override T ReadCommonMember<T>(int memberIndex, TValue value)
         {
             return _commonTable.ExtractValue<T>(memberIndex - _commonTableStartColumn, _codeGenerator.ExtractKey(value));
         }

--- a/DBClientFiles.NET/Internals/Versions/WDB6.cs
+++ b/DBClientFiles.NET/Internals/Versions/WDB6.cs
@@ -45,7 +45,7 @@ namespace DBClientFiles.NET.Internals.Versions
             _commonTableStartColumn = Header.FieldCount;
 
             for (var i = 0; i < Header.FieldCount; ++i)
-                MemberStore.AddFileMemberInfo(this);
+                MemberStore.AddFileMemberInfo(this, Header.HasOffsetMap);
 
             #region Initialize segments
             Records.StartOffset = BaseStream.Position;

--- a/DBClientFiles.NET/Internals/Versions/WDB6.cs
+++ b/DBClientFiles.NET/Internals/Versions/WDB6.cs
@@ -45,7 +45,7 @@ namespace DBClientFiles.NET.Internals.Versions
             _commonTableStartColumn = Header.FieldCount;
 
             for (var i = 0; i < Header.FieldCount; ++i)
-                MemberStore.AddFileMemberInfo(this, Header.HasOffsetMap);
+                MemberStore.AddFileMemberInfo(this);
 
             #region Initialize segments
             Records.StartOffset = BaseStream.Position;

--- a/DBClientFiles.NET/Internals/Versions/WDC1.cs
+++ b/DBClientFiles.NET/Internals/Versions/WDC1.cs
@@ -114,7 +114,8 @@ namespace DBClientFiles.NET.Internals.Versions
         public override void ReadSegments()
         {
             base.ReadSegments();
-            
+
+            OffsetMap.Read();
             _relationshipData.Read();
             _copyTable.Read();
 
@@ -159,6 +160,8 @@ namespace DBClientFiles.NET.Internals.Versions
 
         protected override IEnumerable<TValue> ReadRecords(int recordIndex, long recordOffset, int recordSize)
         {
+            BaseStream.Seek(recordOffset, SeekOrigin.Begin);
+
             _currentRecordIndex = recordIndex;
             using (var recordReader = GetRecordReader(recordSize))
             {

--- a/DBClientFiles.NET/Internals/Versions/WDC2.Section.cs
+++ b/DBClientFiles.NET/Internals/Versions/WDC2.Section.cs
@@ -109,6 +109,7 @@ namespace DBClientFiles.NET.Internals.Versions
                 MemberStore.MapMembers();
                 MemberStore.CalculateCardinalities();
 
+                OffsetMap.Read();
                 _copyTable.Read();
                 _relationshipData.Read();
             }
@@ -125,6 +126,8 @@ namespace DBClientFiles.NET.Internals.Versions
 
             protected override IEnumerable<TValue> ReadRecords(int recordIndex, long recordOffset, int recordSize)
             {
+                BaseStream.Seek(recordOffset, SeekOrigin.Begin);
+
                 using (var recordReader = GetRecordReader(recordSize))
                 {
                     var instance = IndexTable.Exists


### PR DESCRIPTION
Just to summarise:
- Added skipping of the (self-named) `foreignIds` if `Flags & 0x2 != 0`
- Added a `.editorconfig` so I don't destroy your spaces with my tabs 👾 
- Added in the code to use `OffsetMapReader`
  - Forced `ReadRecord` to seek to the provided record offset
  - Fixed a bug in the `OffsetMapReader` indexer
  - Changed the `RecordReader` to use a new `ReadInlineString` function (needs optimising)
  - Changed `AddFileMemberInfo` to accept `OffsetMap.Exists` as to prevent the `MemberInfo.BitSize` being set. I did this as having a bitsize was forcing the use of the packed readers which doesn't work with the `OffsetMap` and it's dastardly variable length inline strings (this needs reviewing)
  - Added deduplication to the `OffsetMapReader` else this throws out the `IndexReader`
- Added a new `Cardinality` calculation that uses the `FileMember` `Offset` and `ByteCount`. You might be able to pass in `RecordSize` to work out if the final field is an array but I'm not sure / I didn't try.

I also merged with your commits and used them over the top of my fixes.

For testing I added the structures for `ItemSparse`, `WMOMinimapTexture` and `Achievement` (which covers all flag combinations) for both 7.2.5.24393 and 7.1.5.23420 (attached below) - however field names aren't correct. For what its worth I tested several random records from each DB against WDBX and they all matched, hopefully that's a good sign!

(I have a compulsive habit of hitting the auto format keyboard shortcut so if I've butchered your nice alignment just line comment it and I'll fix it - sorry)

[Test DBs.zip](https://github.com/Warpten/DBClientFiles.NET/files/2103717/Test.DBs.zip)